### PR TITLE
Make second parameter optional in message function

### DIFF
--- a/src/Commands/FeedCommand.php
+++ b/src/Commands/FeedCommand.php
@@ -211,7 +211,7 @@ class FeedCommand extends Command
         );
     }
 
-    protected function message($type = 'debug', $text= '')
+    protected function message($type = 'debug', $text = '')
     {
         if (!app()->environment('production')) {
             switch ($type) {

--- a/src/Commands/FeedCommand.php
+++ b/src/Commands/FeedCommand.php
@@ -211,7 +211,7 @@ class FeedCommand extends Command
         );
     }
 
-    protected function message($type = 'debug', $text)
+    protected function message($type = 'debug', $text= '')
     {
         if (!app()->environment('production')) {
             switch ($type) {


### PR DESCRIPTION
Update the `message` function to make the second parameter optional, allowing for a default empty string.